### PR TITLE
Added more tick values and y label padding

### DIFF
--- a/client/src/components/Visualization/charts/ScatterPlot.js
+++ b/client/src/components/Visualization/charts/ScatterPlot.js
@@ -114,7 +114,6 @@ const ScatterPlot = () => {
   // Get the min and max tick values for each year in the chart.
   advertisers.forEach(year => {
     const range = getChartRange(year);
-
     ranges.push(range.min);
     ranges.push(range.max);
   });

--- a/client/src/components/Visualization/charts/ScatterPlot.js
+++ b/client/src/components/Visualization/charts/ScatterPlot.js
@@ -15,6 +15,7 @@ import {
   VictoryScatter,
   VictoryTheme,
   VictoryTooltip,
+  VictoryZoomContainer
 } from 'victory';
 
 import { database } from '../../../firebase/firebase';
@@ -26,7 +27,7 @@ const CHART_TITLE_Y = 30;
 const DOMAIN_START = 2017;
 const DOMAIN_END = 2021;
 const Y_LABEL_FONT_SIZE = 10;
-const Y_LABEL_PADDING = 35;
+const Y_LABEL_PADDING = 40;
 
 /**
  * Turn a firestore snap into a victory formatted
@@ -104,23 +105,34 @@ function useAdvertisers(year, queryLimit) {
 const ScatterPlot = () => {
   const queryLimit = 10;
 
-  const advertisers2018 = useAdvertisers("2018", queryLimit);
-  const advertisers2019 = useAdvertisers("2019", queryLimit);
-  const advertisers2020 = useAdvertisers("2020", queryLimit);
+  const advertisers = [useAdvertisers("2018", queryLimit),
+                       useAdvertisers("2019", queryLimit),
+                       useAdvertisers("2020", queryLimit)];
 
-  const advertisers = [...advertisers2018,
-                       ...advertisers2019,
-                       ...advertisers2020];
+  const ranges = [];
 
-  const range = getChartRange(advertisers);
-  const chartTitle = `T${queryLimit} Most prolific ad words advertisers/year`;
+  // Get the min and max tick values for each year in the chart.
+  advertisers.forEach(year => {
+    const range = getChartRange(year);
+
+    ranges.push(range.min);
+    ranges.push(range.max);
+  });
+
+  // Get the global min and max for sizing chart range. 
+  const overallRange = { min: Math.min(...ranges), max: Math.max(...ranges) };
+
+  const chartTitle = `T${queryLimit} Most common ad words advertisers/year`;
 
   return (
     <VictoryChart
+      containerComponent={
+        <VictoryZoomContainer/>
+      }
       theme={VictoryTheme.material}
       domain={{
         x: [DOMAIN_START, DOMAIN_END],
-        y: [range.min * 0.5, range.max * 2],
+        y: [overallRange.min * 0.5, overallRange.max * 2],
       }}
       scale={{ y: 'log' }}
     >
@@ -135,7 +147,7 @@ const ScatterPlot = () => {
 
       <VictoryAxis
         dependentAxis
-        tickValues={[range.min, range.min*2, Math.round(range.max/2), range.max]}
+        tickValues={ranges}
         label="# ads (log scale)"
         style={{ 
             axisLabel: { fontSize: Y_LABEL_FONT_SIZE, padding: Y_LABEL_PADDING }
@@ -147,7 +159,7 @@ const ScatterPlot = () => {
         labels={({ datum }) => datum.y}
         style={{ data: { fill: ({ datum }) => datum.fill } }}
         size={5}
-        data={advertisers}
+        data={advertisers.flat()}
       />
     </VictoryChart>
   );

--- a/client/src/components/Visualization/charts/ScatterPlot.js
+++ b/client/src/components/Visualization/charts/ScatterPlot.js
@@ -25,6 +25,8 @@ const CHART_TITLE_X = 175;
 const CHART_TITLE_Y = 30;
 const DOMAIN_START = 2017;
 const DOMAIN_END = 2021;
+const Y_LABEL_FONT_SIZE = 10;
+const Y_LABEL_PADDING = 35;
 
 /**
  * Turn a firestore snap into a victory formatted
@@ -133,8 +135,11 @@ const ScatterPlot = () => {
 
       <VictoryAxis
         dependentAxis
-        tickValues={[range.min, range.max]}
-        label="# of ads (log scale)"
+        tickValues={[range.min, range.min*2, Math.round(range.max/2), range.max]}
+        label="# ads (log scale)"
+        style={{ 
+            axisLabel: { fontSize: Y_LABEL_FONT_SIZE, padding: Y_LABEL_PADDING }
+        }}
       />
 
       <VictoryScatter


### PR DESCRIPTION
Title. New look: 

![image](https://user-images.githubusercontent.com/11151047/88986433-f5e13980-d2a0-11ea-9707-1abdc056f883.gif)
Added ticks for the min/max advertiser ad count for every year, so 6 ticks total now. 

Also, since Warren went so heavy with ad words ads, I added a zoom component so it's easier to explore everyone else's performance. 