### PR TITLE
Update ReportReader, StateSubcollectionsBuilder

### DIFF
--- a/client/src/components/Visualization/charts/Geochart.js
+++ b/client/src/components/Visualization/charts/Geochart.js
@@ -9,7 +9,7 @@ import { STATES } from '../../../constants/geochart_constants';
 import { database } from '../../../firebase/firebase';
 
 const Geochart = () => {
-  const STATES_COLLECTION = 'dev_states';
+  const STATES_COLLECTION = 'states';
   const [adTotal, setAdTotal] = useState(0);
   const WIDTH = '700';
   const HEIGHT = '400';

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -121,7 +121,7 @@
         <artifactId>exec-maven-plugin</artifactId>
         <version>1.2.1</version>
         <configuration>
-            <mainClass>com.google.sps.utils.StateSubcollectionBuilder</mainClass>
+            <mainClass>com.google.sps.utils.ReportReader</mainClass>
         </configuration>
       </plugin>
     </plugins>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -121,7 +121,7 @@
         <artifactId>exec-maven-plugin</artifactId>
         <version>1.2.1</version>
         <configuration>
-            <mainClass>com.google.sps.utils.ReportReader</mainClass>
+            <mainClass>com.google.sps.utils.StateSubcollectionBuilder</mainClass>
         </configuration>
       </plugin>
     </plugins>

--- a/server/src/main/java/com/google/sps/utils/ReportReader.java
+++ b/server/src/main/java/com/google/sps/utils/ReportReader.java
@@ -25,9 +25,9 @@ public class ReportReader {
   private static final String CSV_FILE_PATH = "/output.csv";
   // NUMBER_CSV_HEADER_ROWS helps the parser know what rows to skip when reading the CSV.
   private static final int NUMBER_CSV_HEADER_ROWS = 2;
-  private static final String COLLECTION;
-  private static final int START_ROW_INDEX; // First row sent to processor (inclusive).
-  private static final int END_ROW_INDEX; // Last row sent to processor (inclusive).
+  private static String COLLECTION;
+  private static int START_ROW_INDEX; // First row sent to processor (inclusive).
+  private static int END_ROW_INDEX; // Last row sent to processor (inclusive).
   private static final String PATH_TO_SERVICE_ACCOUNT = "./serviceAccountKey.json"; 
   private static final String DATABASE_URL = "https://step9-2020-capstone.firebaseio.com"; 
 

--- a/server/src/main/java/com/google/sps/utils/ReportReader.java
+++ b/server/src/main/java/com/google/sps/utils/ReportReader.java
@@ -10,6 +10,7 @@ import java.io.InputStreamReader;
 import java.io.Reader;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Scanner;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVRecord;
@@ -24,9 +25,9 @@ public class ReportReader {
   private static final String CSV_FILE_PATH = "/output.csv";
   // NUMBER_CSV_HEADER_ROWS helps the parser know what rows to skip when reading the CSV.
   private static final int NUMBER_CSV_HEADER_ROWS = 2;
-  private static final String COLLECTION = "ads";
-  private static final int START_ROW_INDEX = 20001;  // First row sent to processor (inclusive).
-  private static final int END_ROW_INDEX = 25000; // Last row sent to processor (inclusive).
+  private static final String COLLECTION;
+  private static final int START_ROW_INDEX; // First row sent to processor (inclusive).
+  private static final int END_ROW_INDEX; // Last row sent to processor (inclusive).
   private static final String PATH_TO_SERVICE_ACCOUNT = "./serviceAccountKey.json"; 
   private static final String DATABASE_URL = "https://step9-2020-capstone.firebaseio.com"; 
 
@@ -59,6 +60,17 @@ public class ReportReader {
 
   public static void main(String[] args) throws IOException, Exception {
     InputStream inputStream = ReportReader.class.getResourceAsStream(CSV_FILE_PATH);
+    
+    // Get collection and number of ads from user.
+    Scanner scanner = new Scanner(System.in);
+    System.out.print("Collection to write to: ");
+    COLLECTION = scanner.nextLine().trim();
+    System.out.print("First row to read (inclusive): ");
+    START_ROW_INDEX = scanner.nextInt();  
+    System.out.print("Last row to read (inclusive): ");
+    END_ROW_INDEX = scanner.nextInt();
+
+    // Read each row of the CSV.
     readCSV(inputStream);
   }
 }

--- a/server/src/main/java/com/google/sps/utils/StateSubcollectionBuilder.java
+++ b/server/src/main/java/com/google/sps/utils/StateSubcollectionBuilder.java
@@ -10,6 +10,7 @@ import com.google.cloud.firestore.Query;
 import com.google.cloud.firestore.QueryDocumentSnapshot;
 import com.google.cloud.firestore.QuerySnapshot;
 import com.google.cloud.firestore.SetOptions;
+import com.google.cloud.firestore.WriteBatch;
 import com.google.cloud.firestore.WriteResult;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
@@ -21,10 +22,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
-import com.google.cloud.firestore.WriteBatch;
-
-
 /**
  * Description: Class creates collection by state. Each state collection contains
  *              two subcollections: 'advertisers', which contains information about
@@ -38,7 +35,7 @@ public class StateSubcollectionBuilder {
   private static final String PATH_TO_SERVICE_ACCOUNT = "./serviceAccountKey.json"; 
   private static final String DATABASE_URL = "https://step9-2020-capstone.firebaseio.com"; 
   private static final String MAIN_COLLECTION = "ads";
-  private static final String WRITE_COLLECTION = "dev_states";
+  private static final String WRITE_COLLECTION = "states";
   private static final Set<String> GEO_TARGETS = Constants.VALID_GEO_TARGETS;
   public static Firestore db; 
 
@@ -69,6 +66,9 @@ public class StateSubcollectionBuilder {
 
     for (QueryDocumentSnapshot document: documentsInState) {
       String advertiser = document.getString("advertiser");
+      
+      // Remove / from document names as they interfere with Firestore paths.
+      advertiser = advertiser.replaceAll("/", " ");
       long maxSpend = document.getLong("spendMax");
 
       if (advertiserSpendMap.containsKey(advertiser)) {

--- a/server/src/main/java/com/google/sps/utils/StateSubcollectionBuilder.java
+++ b/server/src/main/java/com/google/sps/utils/StateSubcollectionBuilder.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
 /**
  * Description: Class creates collection by state. Each state collection contains
  *              two subcollections: 'advertisers', which contains information about


### PR DESCRIPTION
This PR has three purposes:

1. Link the Geochart to the production database
2. Update the ReportReader to fetch user input regarding what collection to write to and the number of ads that should be written
3. Account for a bug in which advertisers have a "/" in their name, which confused the Firestore paths 