### PR TITLE
Refactored string splitting and filtering with simple regex for less pollution

### DIFF
--- a/client/src/constants/word_cloud_constants.js
+++ b/client/src/constants/word_cloud_constants.js
@@ -13,6 +13,7 @@
 const INVALID_STRINGS = new Set([
   '',
   'a',
+  'analyze',
   'and',
   'at',
   'but',
@@ -54,7 +55,7 @@ const WORD_CLOUD_OPTIONS = {
   deterministic: false,
   enableTooltip: true,
   fontFamily: 'impact',
-  fontSizes: [10, 60],
+  fontSizes: [15, 60],
   fontStyle: 'normal',
   fontWeight: 'normal',
   padding: 1,


### PR DESCRIPTION
Title. Current string processing results in a minor amount of inconsistently parsed text. See the boxed text in this image. Basically some words are still combined with others. Additionally, some word counts can be combined but aren't because of apostrophes or dashes etc (e.g., `MIKE'S` should really be part of `MIKE`.)
<img width="796" alt="Word cloud before refinements" src="https://user-images.githubusercontent.com/11151047/89223959-af902100-d5a5-11ea-9e3f-a0b353a6f836.png">
Additionally, the `analyze` button shows up as part of the inner text. Gotta get rid of that. 

Fixed by splitting more aggressively at any non-alphanumeric character, then using the same filtering etc. 

What it looks like now (note this is with dev data so different text input vs picture): 
<img width="784" alt="Word cloud after refinements" src="https://user-images.githubusercontent.com/11151047/89224236-1f9ea700-d5a6-11ea-8797-64ca941b1282.png">
